### PR TITLE
added missing talent charts and make trinkets work again.

### DIFF
--- a/beta/js/Chart_Building.js
+++ b/beta/js/Chart_Building.js
@@ -151,17 +151,16 @@ WCP_Chart.prototype.updateStackedBarChart = function (
       fightStyle;
   }
 
+  let url = "";
+  if (simsBtn == "talents") {
+    url = baseurl + "/" + simsBtn + "/results/Results_" + fightStyle + ".json";
+  } else {
+    url = baseurl + "/" + simsBtn + "/results/Results_" + fightStyle + "_"+ talentChoice + covenantPath + ".json";
+  }
+
   jQuery
     .getJSON(
-      baseurl +
-        "/" +
-        simsBtn +
-        "/results/Results_" +
-        fightStyle +
-        "_" +
-        talentChoice +
-        covenantPath +
-        ".json",
+      url,
       function (data) {
         toUpdateData = "Last Updated: ";
         toUpdateData += data["last_updated"];
@@ -388,17 +387,16 @@ WCP_Chart.prototype.updateSingleBarChart = function (
     chartName = fullTalents + " - " + fullSimType + " - " + fightStyle;
   }
 
+  let url = "";
+  if (simsBtn == "talents") {
+    url = baseurl + "/" + simsBtn + "/results/Results_" + fightStyle + ".json";
+  } else {
+    url = baseurl + "/" + simsBtn + "/results/Results_" + fightStyle + "_"+ talentChoice + covenantPath + ".json";
+  }
+
   jQuery
     .getJSON(
-      baseurl +
-        "/" +
-        simsBtn +
-        "/results/Results_" +
-        fightStyle +
-        "_" +
-        talentChoice +
-        covenantPath +
-        ".json",
+      url,
       function (data) {
         toUpdateData = "Last Updated: ";
         toUpdateData += data["last_updated"];
@@ -774,7 +772,8 @@ function read_config(cfgfile) {
       for (b in sims[s]) {
         if (b == "builds") {
           let values = Object.values(sims[s]);
-          if (values[0] == true) {
+          if (values[0] == true
+                || s == "talents") {
             let builds = true;
             simType.push(s);
           }
@@ -858,7 +857,7 @@ function checkButtonClick() {
   if (itemBtn == "trinkets") {
     //wcp_charts.updateTrinketChart(talentsBtn + itemBtn + fightBtn);
     wcp_charts.updateStackedBarChart("trinkets", fightBtn, talentsBtn);
-    conduitButtons.classList.remove("show");
+    conduitButtons.classList.add("show");
     soulbindButtons.classList.remove("show");
     legendaryButtons.classList.remove("show");
     enchantButtons.classList.remove("show");


### PR DESCRIPTION
I added back the "talents" button, it's more of an "hack" and maybe needs to be reverted, the cause why talents where not visible anymore is the following entrie in the config.yml of sl-shadow-priest

`talents:
    builds: false`

out of that reason the talents got removed.

Additional i added the conduits to show when trinkets are selected, so the website can call the results the proper way.