### PR TITLE
Make button groupings clearer

### DIFF
--- a/css/main-chart.css
+++ b/css/main-chart.css
@@ -265,6 +265,22 @@ input:checked+.slider:before {
   display: block;
 }
 
+/* The sim selection div */
+
+#sims-div {
+  max-width: 950px;
+  align-content: center;
+  margin: auto;
+  margin-bottom: 5px;
+  border: 1px solid #ffffff;
+  border-radius: 8px;
+  padding-bottom: 0px;
+}
+
+#sims-div .button {
+  border: none;
+  border-radius: 0px;
+}
 
 /* Buttons */
 
@@ -276,7 +292,27 @@ input:checked+.slider:before {
   font-size: 14px;
   display: inline-block;
   justify-content: center;
-  border-radius: 8px;
+  border: none;
+  border-top: 1px solid #ffffff;
+  border-bottom: 1px solid #ffffff;
+  cursor: pointer;
+}
+
+.button:first-child {
+  border-radius: 8px 0px 0px 8px;
+  border-left: 1px solid;
+}
+
+.button:last-child {
+  border-radius: 0px 8px 8px 0px;
+  border-right: 1px solid;
+}
+
+.button.selected {
+  background-color: #330066;
+  margin-left: 0px;
+  /* !important used to override #sims-div .button clearing border. */
+  border: 1px solid #dda0dd !important;
 }
 
 

--- a/js/internal/button/Buttons.js
+++ b/js/internal/button/Buttons.js
@@ -112,18 +112,6 @@ function createButtonBasicListSelf(divName, buttonArray, event, labelArray, curr
 }
 
 /*
- * Generates the horizontal spacer between the buttons
- */
-function generateHorizontalSpacer(div) {
-  var horizontalSpacer = document.createElement(span);
-  horizontalSpacer.setAttribute(classLabel, divider);
-  horizontalSpacer.style.width = fivePixel;
-  horizontalSpacer.style.height = auto;
-  horizontalSpacer.style.display = inlineBlock;
-  div.appendChild(horizontalSpacer);
-}
-
-/*
  * add a button to the index.hmtl
  */
 function addButtonShow(buttonName) {
@@ -167,13 +155,8 @@ function styleButtons() {
           || btn.id == currConsumablesBtn
           || btn.id == currFightStyleBtn
           || btn.id == currCovenantChoiceBtn ) {
-      btn.style.borderColor = buttonBorderColor;
-      btn.style.backgroundColor = buttonBackgroundColor;
-    } else {
-      btn.style.borderColor = buttonBorderColorDefault;
-      btn.style.backgroundColor = defaultBackgroundColor;
+      btn.classList.add("selected");
     }
-    btn.style.cursor = pointer;
   }
 }
 
@@ -197,7 +180,6 @@ function createButtonBasic(div, name, event, buttonText, currBtn) {
   button.appendChild(br);
   button.appendChild(buttonText);
   div.appendChild(button);
-  generateHorizontalSpacer(div);
 }
 
 /*

--- a/js/internal/helper/Constants.js
+++ b/js/internal/helper/Constants.js
@@ -8,9 +8,6 @@ const lightColor = "#eeeeee";
 const mediumColor = "#999999";
 const darkColor = "#343a40";
 const gridLineColor = "#616c77";
-const buttonBorderColor = "#DDA0DD";
-const buttonBackgroundColor = "#330066";
-const buttonBorderColorDefault = "white";
 const fontSize = "1.1rem";
 
 /*


### PR DESCRIPTION
Previously, the separate button elements made it hard to know at a glance which buttons were "linked". This updates the CSS a bit to make it clearer which options are part of a single grouping.

Before: ![before](https://user-images.githubusercontent.com/6914695/106084467-406a3400-60d3-11eb-8a08-ad825518d2e7.png)
After: ![after](https://user-images.githubusercontent.com/6914695/106084484-495b0580-60d3-11eb-9957-5103575dfc2c.png)

