### PR TITLE
Add borders between all buttons and a hover color

### DIFF
--- a/css/main-chart.css
+++ b/css/main-chart.css
@@ -268,7 +268,7 @@ input:checked+.slider:before {
 /* The sim selection div */
 
 #sims-div {
-  max-width: 950px;
+  max-width: 890px;
   margin: auto;
   border-radius: 8px;
   overflow: hidden;
@@ -287,6 +287,9 @@ input:checked+.slider:before {
 #sims-btn-wrapper .button {
   border: none;
   border-radius: 0px;
+  padding: 10px;
+  display:flex;
+  align-items: center;
 }
 
 #sims-btn-wrapper .button:first-child {
@@ -305,6 +308,12 @@ input:checked+.slider:before {
   border-bottom-right-radius: 8px;
 }
 
+.sims-btn-icon {
+  width: 16px;
+  height: 16px;
+  position: relative;
+  top: 25%;
+}
 
 /* Buttons */
 

--- a/css/main-chart.css
+++ b/css/main-chart.css
@@ -269,18 +269,42 @@ input:checked+.slider:before {
 
 #sims-div {
   max-width: 950px;
-  align-content: center;
   margin: auto;
-  margin-bottom: 5px;
-  border: 1px solid #ffffff;
   border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #50575f;
+  padding: 0px;
+  margin-bottom: 5px;
+}
+
+#sims-btn-wrapper {
+  display: grid;
+  gap: 1px;
+  background-color: #50575f;
   padding-bottom: 0px;
 }
 
-#sims-div .button {
+#sims-btn-wrapper .button {
   border: none;
   border-radius: 0px;
 }
+
+#sims-btn-wrapper .button:first-child {
+  border-top-left-radius: 8px;
+}
+
+#sims-btn-wrapper .button:nth-child(7) {
+  border-top-right-radius: 8px;
+}
+
+#sims-btn-wrapper .button:nth-child(15) {
+  border-bottom-left-radius: 8px;
+}
+
+#sims-btn-wrapper .button:nth-child(21) {
+  border-bottom-right-radius: 8px;
+}
+
 
 /* Buttons */
 
@@ -292,20 +316,23 @@ input:checked+.slider:before {
   font-size: 14px;
   display: inline-block;
   justify-content: center;
-  border: none;
-  border-top: 1px solid #ffffff;
-  border-bottom: 1px solid #ffffff;
   cursor: pointer;
+  border-width: 1px 0px 1px 1px;
+  border-style: solid;
+  border-color: #50575f;
+}
+
+.button:hover {
+  background-color: #21252b;
 }
 
 .button:first-child {
   border-radius: 8px 0px 0px 8px;
-  border-left: 1px solid;
 }
 
 .button:last-child {
   border-radius: 0px 8px 8px 0px;
-  border-right: 1px solid;
+  border-right: 1px solid #50575f;
 }
 
 .button.selected {
@@ -315,6 +342,9 @@ input:checked+.slider:before {
   border: 1px solid #dda0dd !important;
 }
 
+.button.selected:hover {
+  background-color: #2c0058;
+}
 
 /* Footer */
 

--- a/js/internal/button/Buttons.js
+++ b/js/internal/button/Buttons.js
@@ -80,7 +80,12 @@ function createTalentButtons(buttonArray) {
  * Creates sim buttons
  */
 function createSimsButtons(buttonArray) {
-  createButtonBasicList(simsDiv, buttonArray, checkButtonClick, Sims, sims);
+  const wrapper = document.createElement('div');
+  wrapper.id = "sims-btn-wrapper";
+  wrapper.style = `grid-template-columns: ${'auto '.repeat(maxSimButtonsPerRow)}`;
+  document.getElementById(simsDiv).appendChild(wrapper);
+
+  createButtonBasicList(wrapper.id, buttonArray, checkButtonClick, Sims, sims);
 }
 
 /*
@@ -142,19 +147,27 @@ function removeShow(div) {
 }
 
 /*
+ * Whether or not the button with the given ID is selected in one of the button
+ * groups.
+ */
+function isButtonSelected(buttonId) {
+  return buttonId === currTalentBtn
+    || buttonId === currSimsBtn
+    || buttonId === currCovenantBtn
+    || buttonId === currEnchantsBtn
+    || buttonId === currConsumablesBtn
+    || buttonId === currFightStyleBtn
+    || buttonId === currCovenantChoiceBtn;
+}
+
+/*
  * Handles the colors of the current selected button
  */
 function styleButtons() {
   var btnGroup = document.getElementsByClassName(buttonName);
   for (var i = 0; i < btnGroup.length; i++) {
     let btn = document.getElementById(btnGroup[i].id);
-    if (btn.id == currTalentBtn 
-          || btn.id == currSimsBtn 
-          || btn.id == currCovenantBtn
-          || btn.id == currEnchantsBtn 
-          || btn.id == currConsumablesBtn
-          || btn.id == currFightStyleBtn
-          || btn.id == currCovenantChoiceBtn ) {
+    if (isButtonSelected(btn.id)) {
       btn.classList.add("selected");
     }
   }

--- a/js/internal/button/Buttons.js
+++ b/js/internal/button/Buttons.js
@@ -85,7 +85,22 @@ function createSimsButtons(buttonArray) {
   wrapper.style = `grid-template-columns: ${'auto '.repeat(maxSimButtonsPerRow)}`;
   document.getElementById(simsDiv).appendChild(wrapper);
 
-  createButtonBasicList(wrapper.id, buttonArray, checkButtonClick, Sims, sims);
+  createSimsButtonList(wrapper.id, buttonArray, checkButtonClick, Sims, sims);
+}
+
+/*
+ * Function for creating the buttons specific to the sims div.
+ */
+function createSimsButtonList(divName, buttonArray, event, labelArray, curBtn) {
+  let div = document.getElementById(divName);
+  for (b in buttonArray) {
+    if(b != apl && b != gear) {
+      b = b.replace(dash, underscore);
+      var buttonText = document.createTextNode(getValue(labelArray, b));
+      constructSimsButton(div, b, event, buttonText, curBtn);
+    }
+  }
+  styleButtons();
 }
 
 /*
@@ -171,6 +186,33 @@ function styleButtons() {
       btn.classList.add("selected");
     }
   }
+}
+
+/*
+ * Creates a button specifically with the customizations necessary to correctly
+ * render the sim-related buttons.
+ */
+function constructSimsButton(buttonWrapper, name, event, buttonText, currBtn) {
+  let button = document.createElement(buttonName.toUpperCase());
+  button.setAttribute(buttonId, name);
+  button.setAttribute(buttonClass, buttonName);
+  button.setAttribute(onClick, handleOnClickText + name + attributeSpacer + currBtn + attributeClose);
+  button.addEventListener(click, event);
+
+  const imageWrapper = document.createElement('div');
+  imageWrapper.style = "height: 100%; width: 20px;";
+  var icon = document.createElement('img');
+  icon.src = "images/icons/" + name + ".jpg";
+  icon.classList = "sims-btn-icon";
+  imageWrapper.appendChild(icon);
+  button.appendChild(imageWrapper);
+
+  const textWrapper = document.createElement('div');
+  textWrapper.style = "padding-left: 8px; text-align: left; flex: 1;"
+  textWrapper.appendChild(buttonText);
+  button.appendChild(textWrapper);
+
+  buttonWrapper.appendChild(button);
 }
 
 /*

--- a/js/internal/helper/Constants.js
+++ b/js/internal/helper/Constants.js
@@ -121,6 +121,7 @@ const consumables = "consumables";
 const covenants = "covenants";
 const covenantsChoice = "covenant_choice";
 const weights = "weights";
+const maxSimButtonsPerRow = 7;
 
 const pointer = "pointer";
 const attributeSpacer = "', '";


### PR DESCRIPTION
Adds:
* More subtle border color
* Borders between all buttons in a group (while keeping groups obvious)
* Slight color change on hover

Current borders:
![image](https://user-images.githubusercontent.com/6914695/106373040-92f15d80-632a-11eb-8726-d10640dc9529.png)

New borders (including hover on Surrender to Madness):
![image](https://user-images.githubusercontent.com/6914695/106373012-54f43980-632a-11eb-9e7a-29c51eb39ac1.png)

New borders (with highlight on a corner):
![image](https://user-images.githubusercontent.com/6914695/106373025-72c19e80-632a-11eb-9a80-19b343adcf20.png)
