### PR TITLE
Make council fight style dynamic

### DIFF
--- a/js/internal/button/Buttons.js
+++ b/js/internal/button/Buttons.js
@@ -17,18 +17,18 @@ function initializeButtons() {
   if(query !== null) {
     if(query.has(talents)) {
       if(query.get(talents) != null
-          || query.get(talents) != "")
-      currTalentBtn = query.get(talents);
+        || query.get(talents) != "")
+        currTalentBtn = query.get(talents);
     }
     if(query.has(sims)) {
-    if( query.get(sims) != null
-      || query.get(sims) != "")
-      currSimsBtn = query.get(sims);
+      if( query.get(sims) != null
+        || query.get(sims) != "")
+        currSimsBtn = query.get(sims);
     }
+
     if(query.has(fightStyle)) {
-      if(query.get(fightStyle) != null
-        || query.get(fightStyle) != "")
-      currFightStyleBtn = query.get(fightStyle); 
+      if(Object.hasOwn(getAvailableFightStyles(), query.get(fightStyle)))
+        currFightStyleBtn = query.get(fightStyle); 
     }
     if(query.has(version)) {
       if(query.get(version) != null
@@ -47,8 +47,18 @@ function createButtons() {
   createTalentButtons(configData[builds]);
   createSimsButtons(configData[sims]);
   createConsumableButtons(getKeys(Consumables));
-  createFightStyleButtons(getKeys(FightStyles));
+  createFightStyleButtons(getKeys(getAvailableFightStyles()));
   checkButtonClick();
+}
+
+function getAvailableFightStyles() {
+  // TODO: Make council fight style optinal?
+  let currentCouncilFightStyle = FightStyleCouncil[configData["councilTargets"]]
+  let councilFightStyles = Object.values(FightStyleCouncil)
+  return Object.entries(FightStyles).reduce(function(prev, [key, value]) {
+    if(councilFightStyles.includes(key) && key !== currentCouncilFightStyle) return prev
+    return { ...prev, [key]: value }
+  }, {})
 }
 
 /*

--- a/js/internal/helper/Converter.js
+++ b/js/internal/helper/Converter.js
@@ -31,10 +31,15 @@ var FightStyles = {
   Single: "Single Target",
   Dungeons: "Dungeons",
   twotarget: "2 Target",
-  // threetarget: "3 Target",
+  threetarget: "3 Target",
   fourtarget: "4 Target",
   eighttarget: "8 Target",
 };
+
+var FightStyleCouncil = {
+  3: "threetarget",
+  4: "fourtarget"
+}
   
 var FightStyleExternal = {
   composite: "Raid",


### PR DESCRIPTION
Determine council fight style with new config entry, allowing different council targets between live and ptr version.

**Live Example**
![image](https://github.com/user-attachments/assets/aa03df67-5535-45bc-829e-c657a10fa2ad)

**PTR Example**
![image](https://github.com/user-attachments/assets/9279c23b-56fb-4cc6-8a8b-ca0cc26b783d)
